### PR TITLE
Adjust the MSRV to 1.63.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,15 @@ edition = "2021"
 keywords = ["linux", "procfs"]
 categories = ["os::unix-apis"]
 include = ["src", "Cargo.toml", "COPYRIGHT", "LICENSE*", "/*.md"]
-rust-version = "1.70"
+rust-version = "1.63"
 
 [dependencies]
 rustix = { version = "1.0.0", default-features = false, features = ["alloc", "fs"] }
 once_cell = "1.5.2"
+
+[features]
+default = ["std"]
+std = ["rustix/std"]
 
 [dev-dependencies]
 rustix = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ of the paths we open.
 
 Why all the effort to detect bind mount points? People are doing all kinds of
 things with Linux containers these days, with many different privilege schemes,
-and we want to avoid making any unnecessary assumptions. Rustix and its users
+and we want to avoid making any unnecessary assumptions. Libraries
 will sometimes use procfs *implicitly* (when Linux gives them no better
 options), in ways that aren't obvious from their public APIs. These filesystem
 accesses might not be visible to someone auditing the main code of an


### PR DESCRIPTION
Enable the std feature in rustix by default, because rustix's no-std support doesn't support Rust 1.63.